### PR TITLE
Adding stuff to unit-config for reading in a config from a file

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -184,8 +184,8 @@ func (bob *Builder) setup() Error {
 	meta := bob.nextSubSequence.Metadata
 	dockerfile := meta.Dockerfile
 	opts := filecheck.NewTrustedFilePathOptions{File: dockerfile, Top: bob.contextDir}
-	pathToDockerfile = filecheck.NewTrustedFilePath(opts)
-	if pathToDockerfile.State == filecheck.Errored {
+	pathToDockerfile, err = filecheck.NewTrustedFilePath(opts)
+	if err != nil {
 		return &buildRelatedError{
 			Message: err.Error(),
 			Code:    1,

--- a/filecheck/trusted_file_path.go
+++ b/filecheck/trusted_file_path.go
@@ -43,7 +43,7 @@ type NewTrustedFilePathOptions struct {
 // sanitized by evaluating all symlinks so that it can be properly sanitized by
 // the builder when the time comes.  This treats "top" as trusted (i.e.
 // relative paths and symlinks can be evaluated safely).
-func NewTrustedFilePath(opts NewTrustedFilePathOptions) *TrustedFilePath {
+func NewTrustedFilePath(opts NewTrustedFilePathOptions) (*TrustedFilePath, error) {
 	top := opts.Top
 	file := opts.File
 	if top == "" {
@@ -54,7 +54,7 @@ func NewTrustedFilePath(opts NewTrustedFilePathOptions) *TrustedFilePath {
 		return &TrustedFilePath{
 			State: Errored,
 			Error: err,
-		}
+		}, err
 	}
 
 	resolved, err := filepath.EvalSymlinks(abs)
@@ -62,14 +62,14 @@ func NewTrustedFilePath(opts NewTrustedFilePathOptions) *TrustedFilePath {
 		return &TrustedFilePath{
 			State: Errored,
 			Error: err,
-		}
+		}, err
 	}
 
 	return &TrustedFilePath{
 		file:  file,
 		top:   resolved,
 		State: Unchecked,
-	}
+	}, nil
 }
 
 // File returns the file component of the trusted file path

--- a/unit-config/read.go
+++ b/unit-config/read.go
@@ -1,7 +1,117 @@
 package unitconfig
 
 import (
-//"github.com/sylphon/build-runner/filecheck"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/sylphon/build-runner/filecheck"
+	"gopkg.in/yaml.v2"
 )
 
-//func ReadFromFile(
+// Encoding is a constant that represents the config format of a file
+// that is expected to contain an encoded unit-config
+type Encoding int
+
+const (
+	// TOML is for files encoded with TOML (or ending in .toml)
+	TOML Encoding = iota
+
+	// JSON is for files encoded in JSON (or ending in .json)
+	JSON
+
+	// YAML is for files encoded in YAML (or ending in .yml or .yaml)
+	YAML
+
+	unknown
+)
+
+// ReadFromFile accepts an unsanitized path to a Bobfile and returns the
+// decoded UnitConfig.  The value of encodings is a list of possible file
+// encodings.  If none is provided, the encoding will be inferred from the file
+// extension as described in the documentation for the UnitConfigEncoding
+// constants.  If no encoding can be inferred, TOML will be used as the default.
+func ReadFromFile(path string, encodings ...Encoding) (*UnitConfig, error) {
+	// check file
+	if path == "" {
+		return nil, errors.New("no file path provided")
+	}
+
+	top := filepath.Dir(path)
+	filename := filepath.Base(path)
+	opts := filecheck.NewTrustedFilePathOptions{
+		File: filename,
+		Top:  top,
+	}
+
+	var file *filecheck.TrustedFilePath
+	var err error
+	if file, err = filecheck.NewTrustedFilePath(opts); err != nil {
+		return nil, err
+	}
+	if file.Sanitize(); file.State != filecheck.OK {
+		return nil, errors.New("provided file is unchecked or unsanitary")
+	}
+
+	// file is sanitary
+
+	contents, err := ioutil.ReadFile(file.FullPath())
+	if err != nil {
+		return nil, err
+	}
+
+	// attempt to infer encoding by file extension
+	if encodings == nil || len(encodings) == 0 {
+		inferred := inferredEncoding(file)
+		if inferred == unknown {
+			inferred = TOML
+		}
+		encodings = []Encoding{inferred}
+	}
+
+	// return first validly-decoded UnitConfig
+	for _, encoding := range encodings {
+		switch encoding {
+		case TOML:
+			ret := &UnitConfig{}
+			if _, err = toml.Decode(string(contents), &ret); err == nil {
+				return ret, nil
+			}
+		case JSON:
+			decoder := json.NewDecoder(bytes.NewReader(contents))
+			ret := &UnitConfig{}
+			if err := decoder.Decode(ret); err == nil {
+				return ret, nil
+			}
+		case YAML:
+			ret := &UnitConfig{}
+			if err = yaml.Unmarshal(contents, &ret); err == nil {
+				return ret, nil
+			}
+		}
+	}
+
+	if err == nil {
+		err = errors.New("unable to decode file contents")
+	}
+
+	return nil, err
+}
+
+func inferredEncoding(file *filecheck.TrustedFilePath) Encoding {
+	ext := strings.ToLower(filepath.Ext(file.File()))
+	switch ext {
+	case "json":
+		return JSON
+	case "toml":
+		return TOML
+	case "yaml", "yml":
+		return YAML
+	default:
+		return unknown
+	}
+}


### PR DESCRIPTION
Adding code to read in a `UnitConfig` (formerly `Bobfile`) from a file - this is to make for a simpler integration with the existing `docker-builder`
