### PR TITLE
Add the image_id to the command logs after the command runs. The control...

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -130,6 +130,13 @@ func (bob *Builder) BuildCommandSequence(commandSequence *parser.CommandSequence
 					return err
 				}
 			}
+
+			bob.reporter.Log(
+				l.WithFields(l.Fields{
+					"command":  cmd.Message(),
+					"image_id": imageID,
+				}),
+				"finished running docker command")
 		}
 
 		bob.attemptToDeleteTemporaryUUIDTag(seq.Metadata.UUID)


### PR DESCRIPTION
...ler will need this information shortly.
